### PR TITLE
tlschecker: Add remaining check for Logjam

### DIFF
--- a/features/tlschecker.feature
+++ b/features/tlschecker.feature
@@ -78,6 +78,11 @@ Feature: Test TLS server-side configuration
          | ECDHE.*-GCM       |
          | ECDHE.*AES256     |
 
+  Scenario: The server uses a strong D-H group
+    # Mitigation for Logjam vulnerability
+    Given a stored connection result
+    Then the D-H group size is at least "2048" bits
+
   Scenario: The server certificate should be trusted
     Given a stored connection result
     Then the certificate has a matching host name

--- a/mittn/tlschecker/steps.py
+++ b/mittn/tlschecker/steps.py
@@ -108,6 +108,23 @@ def step_impl(context):
         "Certificate subject does not match host name"
 
 
+@step(u'the D-H group size is at least "{groupsize}" bits')
+def step_impl(context, groupsize):
+    try:
+        root = context.xmloutput.getroot()
+    except AttributeError:
+        assert False, "No stored TLS connection result set was found."
+    keyexchange = root.find(".//keyExchange")
+    if keyexchange is None:
+       # Kudos bro!
+        return
+    keytype = keyexchange.get('Type')
+    realgroupsize = keyexchange.get('GroupSize')
+    if keytype == 'DH':
+        assert int(groupsize) <= int(realgroupsize), \
+            "D-H group size less than %s" % groupsize
+
+
 @step(u'the public key size is at least "{keysize}" bits')
 def step_impl(context, keysize):
     try:


### PR DESCRIPTION
Specifically this adds a check for a strong Diffie Hellman Group.

Mitigating Logjam involves all these three, but 1) and 2) are caught by
other existing checks:
 1) Disable Export Cipher Suites
 2) Deploy (Ephemeral) Elliptic-Curve Diffie-Hellman (ECDHE)
 3) Use a Strong, Diffie Hellman Group
(source: https://weakdh.org/sysadmin.html)