### PR TITLE
New: Python packaging support

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+pip install pip\>=8.0.0
+pip install -r dev-requirements.txt
+python setup.py develop

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+setuptools-scm >= 1.11.0

--- a/mittn/__init__.py
+++ b/mittn/__init__.py
@@ -1,0 +1,2 @@
+import pkgutil
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_packages
+
+
+setup(
+    name='mittn',
+    use_scm_version=True,
+    description='Mittn',
+    long_description=open('README.txt').read(),
+    classifiers=[
+          "Programming Language :: Python :: 2.7"
+    ],
+    license='Apache License 2.0',
+    author='F-Secure Corporation',
+    author_email='opensource@f-secure.com',
+    url='https://github.com/F-Secure/mittn',
+    packages=find_packages(exclude=['features']),
+    install_requires=open('requirements.txt').readlines(),
+)


### PR DESCRIPTION
Version is determined from git revision through setuptools-scm.

Is python 2.7 really the minimum supported?